### PR TITLE
Adding a mock_authentication config flag

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -267,7 +267,7 @@ class LDAPAuthenticator(Authenticator):
         conn = self.get_connection(
             userdn=search_dn, password=self.lookup_dn_search_password
         )
-        is_bound = conn.bind() and not self.mock_authentication
+        is_bound = conn.bind()
         if not is_bound:
             msg = "Failed to connect to LDAP server with search user '{search_dn}'"
             self.log.warning(msg.format(search_dn=search_dn))
@@ -338,6 +338,7 @@ class LDAPAuthenticator(Authenticator):
     def get_connection(self, userdn, password):
         
         if self.mock_authentication:
+            self.log.warning("Using a mock LDAP server.")
             server = ldap3.Server('my_fake_server')
             conn = ldap3.Connection(
                 server, 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -267,7 +267,7 @@ class LDAPAuthenticator(Authenticator):
         conn = self.get_connection(
             userdn=search_dn, password=self.lookup_dn_search_password
         )
-        is_bound = conn.bind()
+        is_bound = conn.bind() and not self.mock_authentication
         if not is_bound:
             msg = "Failed to connect to LDAP server with search user '{search_dn}'"
             self.log.warning(msg.format(search_dn=search_dn))

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -337,7 +337,7 @@ class LDAPAuthenticator(Authenticator):
 
     def get_connection(self, userdn, password):
         
-        if mock_authentication:
+        if self.mock_authentication:
             server = ldap3.Server('mock_server')
             connection = ldap3.Connection(
                 server, 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -31,7 +31,7 @@ class LDAPAuthenticator(Authenticator):
     
     mock_authentication = Bool(
         config=True,
-        default=False
+        default=False,
         help="""
         Mock auth locally rather than contacting a server.
         Only use this for development.

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -440,7 +440,7 @@ class LDAPAuthenticator(Authenticator):
             if is_bound:
                 break
 
-        if not is_bound self.mock_authentication:
+        if not is_bound or self.mock_authentication:
             msg = "Invalid password for user '{username}'"
             self.log.warning(msg.format(username=username))
             return None

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -339,11 +339,11 @@ class LDAPAuthenticator(Authenticator):
         
         if self.mock_authentication:
             self.log.warning("Using a mock LDAP server.")
-            server = ldap3.Server('my_fake_server')
+            server = ldap3.Server(self.server_address)
             conn = ldap3.Connection(
                 server, 
-                user='cn=my_user,ou=test,o=lab', 
-                password='my_password',
+                user=userdn, 
+                password=password,
                 client_strategy=ldap3.MOCK_SYNC
             )
             conn.strategy.add_entry(
@@ -440,7 +440,7 @@ class LDAPAuthenticator(Authenticator):
             if is_bound:
                 break
 
-        if not is_bound or self.mock_authentication:
+        if not (is_bound or self.mock_authentication):
             msg = "Invalid password for user '{username}'"
             self.log.warning(msg.format(username=username))
             return None

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -347,7 +347,7 @@ class LDAPAuthenticator(Authenticator):
             )
             connection.strategy.add_entry(
                 'CN=Mock User,OU=Windows 10 Users,OU=CMA,DC=cma,DC=gov,DC=uk', 
-                {'userPassword': 'mock_password', 'sn': 'user0_sn', 'revision': 0}
+                {'userPassword': 'mock_password', 'sn': 'user0_sn', 'revision': 0, 'sAMAccountName':'mock.user'}
             )
 
         else:

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -440,7 +440,7 @@ class LDAPAuthenticator(Authenticator):
             if is_bound:
                 break
 
-        if not is_bound:
+        if not is_bound self.mock_authentication:
             msg = "Invalid password for user '{username}'"
             self.log.warning(msg.format(username=username))
             return None

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -267,7 +267,7 @@ class LDAPAuthenticator(Authenticator):
         conn = self.get_connection(
             userdn=search_dn, password=self.lookup_dn_search_password
         )
-        is_bound = conn.bind() and not self.mock_authentication
+        is_bound = conn.bind() or self.mock_authentication
         if not is_bound:
             msg = "Failed to connect to LDAP server with search user '{search_dn}'"
             self.log.warning(msg.format(search_dn=search_dn))

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -339,13 +339,13 @@ class LDAPAuthenticator(Authenticator):
         
         if self.mock_authentication:
             server = ldap3.Server('mock_server')
-            connection = ldap3.Connection(
+            conn = ldap3.Connection(
                 server, 
                 user='CN=mock_svc,OU=Windows 10 Users,OU=CMA,DC=cma,DC=gov,DC=uk', 
                 password='mock_svc_password', 
                 client_strategy=ldap3.MOCK_SYNC
             )
-            connection.strategy.add_entry(
+            conn.strategy.add_entry(
                 'CN=Mock User,OU=Windows 10 Users,OU=CMA,DC=cma,DC=gov,DC=uk', 
                 {'userPassword': 'mock_password', 'sn': 'user0_sn', 'revision': 0, 'sAMAccountName':'mock.user'}
             )

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -338,11 +338,11 @@ class LDAPAuthenticator(Authenticator):
     def get_connection(self, userdn, password):
         
         if self.mock_authentication:
-            server = ldap3.Server('mock_server')
+            server = ldap3.Server('my_fake_server')
             conn = ldap3.Connection(
                 server, 
-                user='CN=mock_svc,OU=Windows 10 Users,OU=CMA,DC=cma,DC=gov,DC=uk', 
-                password='mock_svc_password', 
+                user='cn=my_user,ou=test,o=lab', 
+                password='my_password',
                 client_strategy=ldap3.MOCK_SYNC
             )
             conn.strategy.add_entry(


### PR DESCRIPTION
Users are able to login in with mock.user, mock_password when this is true